### PR TITLE
Update AltSource download url to version 2.0r2

### DIFF
--- a/AltSource.json
+++ b/AltSource.json
@@ -4,7 +4,7 @@
       "beta": false,
       "bundleIdentifier": "com.atebits.Tweetie2",
       "developerName": "actuallyaridan, nyaathea, timi2506",
-      "downloadURL": "https://github.com/NeoFreeBird/app/releases/download/2.0/NeoFreeBird-2.0-Twitter-11.5.5.ipa",
+      "downloadURL": "https://github.com/NeoFreeBird/app/releases/download/2.0/NeoFreeBird-2.0r2-Twitter-11.5.5.ipa",
       "iconURL": "https://raw.githubusercontent.com/actuallyaridan/NeoFreeBird/refs/heads/main/Branding/Icon.png",
       "localizedDescription": "A modified Twitter app, with branding reverts, BHTwitter and other QoL modifications.",
       "name": "NeoFreeBird",


### PR DESCRIPTION
The repo in AltStore doesn't work because the current download url, `https://github.com/NeoFreeBird/app/releases/download/2.0/NeoFreeBird-2.0-Twitter-11.5.5.ipa`, 404s.