### PR TITLE
Update macOS version for build job to macos-14

### DIFF
--- a/.github/workflows/Build-NeoFreeBird.yml
+++ b/.github/workflows/Build-NeoFreeBird.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   build-and-inject:
     name: Build NeoFreeBird
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       contents: write
 


### PR DESCRIPTION
This will update the workflow via Github Actions to use macos-14.  That is because `macos-13` has been retired per https://github.com/actions/runner-images/issues/13046